### PR TITLE
Enable easy publishing of image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+publish-image:
+	rm -rf target
+	mvn package
+	cp target/heron-starter-*-jar-with-dependencies.jar ./docker/
+	docker build docker/ -t streamlio/sandbox:latest
+	docker push streamlio/sandbox:latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-publish-image:
+clean:
 	rm -rf target
+
+build-image: clean
 	mvn package
 	cp target/heron-starter-*-jar-with-dependencies.jar ./docker/
 	docker build docker/ -t streamlio/sandbox:latest
+
+publish-image: build-image
 	docker push streamlio/sandbox:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,7 @@ COPY streamlio.conf /etc/supervisor/conf.d/
 COPY apply-config-from-env.py /pulsar/bin
 
 # Copy topology jars
-COPY heron-starter-0.0.1-SNAPSHOT-jar-with-dependencies.jar /components
+COPY heron-starter-*-jar-with-dependencies.jar /components/
 
 # Settings for lower memory consumption
 ENV PULSAR_MEM '" -Xmx512M -XX:MaxDirectMemorySize=512M"'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>heron.starter</groupId>
   <artifactId>heron-starter</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>heron-starter</name>


### PR DESCRIPTION
This adds a basic `make` command for publishing the sandbox Docker image (for anyone logged in to Docker Hub) and makes some small changes to the image build process.

I also bumped the version of the sandbox to 0.0.2.

> **NOTE**: I've already re-published this image with the new "pattern detection" topology and this `make` command worked as expected.